### PR TITLE
Sbt support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,3 @@
+// This project uses the sbt-pom-reader plugin.
+// Most of the dependencies are specified in pom.xml
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.11.4</scala.version>
+    <scala.version>2.11.7</scala.version>
   </properties>
 
   <repositories>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,0 +1,2 @@
+import sbt._
+object MyBuild extends com.typesafe.sbt.pom.PomBuild

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-pom-reader" % "2.0.0")


### PR DESCRIPTION
This PR adds additional support for building and testing the project using SBT with the sbt-pom-reader plugin.
Except for an update of the Scala version, the pom.xml is unmodified.
