### PR TITLE
Rowstacked barchart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.sameersingh.scalaplot</groupId>
   <artifactId>scalaplot</artifactId>
-  <version>0.2-SNAPSHOT</version>
+  <version>0.3-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <description>Library for plotting the results of experiments</description>
   <url>http://www.sameersingh.org/scalaplot</url>

--- a/src/main/scala/org/sameersingh/scalaplot/BarChart.scala
+++ b/src/main/scala/org/sameersingh/scalaplot/BarChart.scala
@@ -69,6 +69,8 @@ class BarChart(chartTitle: Option[String], val data: BarData,
   def this(chartTitle: String, data: BarData) = this(Some(chartTitle), data)
 
   def this(data: BarData) = this(None, data)
+
+  override def title = chartTitle
 }
 
 trait BarSeriesImplicits {

--- a/src/main/scala/org/sameersingh/scalaplot/BarChart.scala
+++ b/src/main/scala/org/sameersingh/scalaplot/BarChart.scala
@@ -65,7 +65,9 @@ class BarData(val names: (Int) => String = _.toString,
 
 
 class BarChart(chartTitle: Option[String], val data: BarData,
+               val style: HistogramStyle.Type = HistogramStyle.Cluster,
                val x: DiscreteAxis = new DiscreteAxis, val y: NumericAxis = new NumericAxis) extends Chart {
+
   def this(chartTitle: String, data: BarData) = this(Some(chartTitle), data)
 
   def this(data: BarData) = this(None, data)
@@ -194,9 +196,10 @@ trait BarChartImplicits extends BarDataImplicits {
                legendPosY: LegendPosY.Type = LegendPosY.Center,
                showLegend: Boolean = false,
                monochrome: Boolean = false,
-               size: Option[(Double, Double)] = None
+               size: Option[(Double, Double)] = None,
+               style: HistogramStyle.Type = HistogramStyle.Cluster
                 ): BarChart = {
-    val c = new BarChart(GlobalImplicits.stringToOptionString(title), data, {
+    val c = new BarChart(GlobalImplicits.stringToOptionString(title), data, style, {
       val d = new DiscreteAxis();
       d.label = xLabel;
       d

--- a/src/main/scala/org/sameersingh/scalaplot/Style.scala
+++ b/src/main/scala/org/sameersingh/scalaplot/Style.scala
@@ -24,4 +24,9 @@ object Style {
     type Type = Value
     val Empty, Solid, Pattern = Value
   }
+
+  object HistogramStyle extends Enumeration {
+    type Type = Value
+    val Cluster, RowStacked = Value
+  }
 }

--- a/src/main/scala/org/sameersingh/scalaplot/gnuplot/GnuplotPlotter.scala
+++ b/src/main/scala/org/sameersingh/scalaplot/gnuplot/GnuplotPlotter.scala
@@ -1,5 +1,6 @@
 package org.sameersingh.scalaplot.gnuplot
 
+import org.sameersingh.scalaplot.Style.HistogramStyle.{RowStacked, Cluster}
 import org.sameersingh.scalaplot._
 import collection.mutable.ArrayBuffer
 import java.io.{InputStreamReader, BufferedReader, File, PrintWriter}
@@ -112,6 +113,13 @@ class GnuplotPlotter(chart: Chart) extends Plotter(chart) {
     sb.toString
   }
 
+  protected def getHistogramStyle(s: HistogramStyle.Type): String = {
+    s match {
+      case Cluster => "cluster gap 1"
+      case RowStacked => "rowstacked"
+    }
+  }
+
   def plotChart(chart: Chart, defaultTerminal: String = "dumb") {
     lines += "# Chart settings"
     chart.title.foreach(t => lines += "set title \"%s\"" format (t))
@@ -133,13 +141,13 @@ class GnuplotPlotter(chart: Chart) extends Plotter(chart) {
     lines += "set yr [%s:%s] %sreverse" format(yr1s, yr2s, if (chart.y.isBackward) "" else "no")
     lines += "set xlabel \"%s\"" format (chart.x.label)
     lines += "set ylabel \"%s\"" format (chart.y.label)
+    lines += "set style histogram %s" format (getHistogramStyle(chart.style))
     plotBarData(chart.data)
   }
 
   def plotBarData(data: BarData) {
     lines += "# BarData Plotting"
     lines += "set style data histogram"
-    lines += "set style histogram cluster gap 1"
     lines += "set style fill solid border -1"
     lines += "plot \\"
     var index = 0


### PR DESCRIPTION
For some data a stacked bar chart is more clear. E.g. jstack heap utilization graph:
![jstatgc-result-20160214-heap-utilization](https://cloud.githubusercontent.com/assets/4989266/13033757/4a7e92dc-d32b-11e5-995e-46b93903f997.png)

Added option to choose between cluster or stacked bar chart styles.
By default cluster type will be used as it was before.

Fixed minor bug  - bar chart title was not being displayed.
