### PR TITLE
fix typo "pointsize"

### DIFF
--- a/src/main/scala/org/sameersingh/scalaplot/gnuplot/GnuplotPlotter.scala
+++ b/src/main/scala/org/sameersingh/scalaplot/gnuplot/GnuplotPlotter.scala
@@ -115,7 +115,7 @@ class GnuplotPlotter(chart: Chart) extends Plotter(chart) {
   def plotChart(chart: Chart, defaultTerminal: String = "dumb") {
     lines += "# Chart settings"
     chart.title.foreach(t => lines += "set title \"%s\"" format (t))
-    chart.pointSize.foreach(t => lines += "set pointSize %f" format (t))
+    chart.pointSize.foreach(t => lines += "set pointsize %f" format (t))
     // legend
     if (chart.showLegend) {
       lines += "set key %s %s" format(chart.legendPosX.toString.toLowerCase, chart.legendPosY.toString.toLowerCase)


### PR DESCRIPTION
When I use a `pointSize` option, failed to generate output with no error.

``` scala
output(PNG("./", "a"), xyChart(Seq(1.0d, 2.0d, 3.0d) -> Y(Seq(2.0d, 3.0d, 4.0d), style = XYPlotStyle.Points), pointSize = Some(3.0d)))
```

And then, I execute gnuplot manually by `gnuplot a.gpl`, I got following errors.

```
set pointSize 3.000000
    ^
"a.gpl", line 2: unrecognized option - see 'help set'.
```
