### PR TITLE
gnuplot point size fix

### DIFF
--- a/src/main/scala/org/sameersingh/scalaplot/gnuplot/GnuplotPlotter.scala
+++ b/src/main/scala/org/sameersingh/scalaplot/gnuplot/GnuplotPlotter.scala
@@ -115,7 +115,7 @@ class GnuplotPlotter(chart: Chart) extends Plotter(chart) {
   def plotChart(chart: Chart, defaultTerminal: String = "dumb") {
     lines += "# Chart settings"
     chart.title.foreach(t => lines += "set title \"%s\"" format (t))
-    chart.pointSize.foreach(t => lines += "set pointSize %f" format (t))
+    chart.pointSize.foreach(t => lines += "set pointsize %f" format (t))
     // legend
     if (chart.showLegend) {
       lines += "set key %s %s" format(chart.legendPosX.toString.toLowerCase, chart.legendPosY.toString.toLowerCase)


### PR DESCRIPTION
When gnuplot is used and poistSize is set, scalaplot produces no output image, only scatter.gpl.
Manual gnuplot execution is terminated with the following error (as I understood, gnuplot expects "pointsize" in lowercase):

```
$ gnuplot scatter.gpl

set pointSize 5.000000
    ^
"scatter.gpl", line 2: unrecognized option - see 'help set'.
```

Also pointsize parameter is ignored with style = XYPlotStyle.Dots, perhaps, warning should be raised when both these settings are set.
